### PR TITLE
Change Ritual Beast Ulti- to Ritual Beast Ulti

### DIFF
--- a/locales/en-US/strings.conf
+++ b/locales/en-US/strings.conf
@@ -843,7 +843,7 @@
 !setname 0xb5 Ritual Beast
 !setname 0x10b5 Ritual Beast Tamer
 !setname 0x20b5 Spiritual Beast
-!setname 0x40b5 Ritual Beast Ulti-
+!setname 0x40b5 Ritual Beast Ulti
 !setname 0xb6 Outer Entity
 !setname 0xb7 Elder Entity
 !setname 0xb8 Old Entity


### PR DESCRIPTION
This archetype shouldnt have that character, that can be proven if we look at one of the members:
Ritual Beast Ulti-Gaiapelio is a Fusion Monster that requires
**1 "Ritual Beast Ulti" monster** + 1 "Ritual Beast Tamer" monster + 1 "Spiritual Beast" monster