### PR TITLE
fix strings.conf

### DIFF
--- a/locales/en-US/strings.conf
+++ b/locales/en-US/strings.conf
@@ -816,7 +816,7 @@
 !setname 0x73 Xyz
 !setname 0x1073 CXyz
 !setname 0x2073 Xyz Dragon
-!setname 0x2073 Armored Xyz
+!setname 0x4073 Armored Xyz
 !setname 0x74 Mermail
 !setname 0x75 Abyss-
 !setname 0x76 Heraldic Beast


### PR DESCRIPTION
Setcodes for "Xyz Dragon" & "Armored Xyz" archetypes were equivalent