### PR TITLE
Revert en-US cards.cdb to 26 Apr version

### DIFF
--- a/locales/en-US/strings.conf
+++ b/locales/en-US/strings.conf
@@ -566,7 +566,7 @@
 !counter 0x4 Psychic Counter
 !counter 0x5 Shine Counter
 !counter 0x6 Gem Counter
-!counter 0x7 Counter(Colosseum - Cage of the Gladiator Beasts)
+!counter 0x7 Counter(Colosseum Cage of the Gladiator Beasts)
 !counter 0x8 D Counter
 !counter 0x1009 Venom Counter
 !counter 0xa Genex Counter
@@ -576,7 +576,7 @@
 !counter 0x100e A-Counter
 !counter 0xf Worm Counter
 !counter 0x10 Black Feather Counter
-!counter 0x11 Hyper-Venom Counter
+!counter 0x11 Hyper Venom Counter
 !counter 0x12 Karakuri Counter
 !counter 0x13 Chaos Counter
 !counter 0x14 Counter(Miracle Jurassic Egg)
@@ -599,7 +599,7 @@
 !counter 0x25 Chronicle Counter
 !counter 0x26 Counter(Metal Shooter)
 !counter 0x27 Counter(Des Mosquito)
-!counter 0x28 Counter(Dark Catapulter)
+!counter 0x28 Counter (Dark Catapulter)
 !counter 0x29 Counter(Balloon Lizard)
 !counter 0x102a Counter(Magic Reflector)
 !counter 0x2b Destiny Counter
@@ -607,7 +607,7 @@
 !counter 0x2d Counter(Kickfire)
 !counter 0x2e Shark Counter
 !counter 0x2f Pumpkin Counter
-!counter 0x30 Hi-Five the Sky Counter
+!counter 0x30 Feel the Flow Counter
 !counter 0x31 Rising Sun Counter
 !counter 0x32 Balloon Counter
 !counter 0x33 Yosen Counter
@@ -645,15 +645,15 @@
 !counter 0x59 Otoshidamashii Counters
 !counter 0x5a Counter(War Rock Ordeal)
 !counter 0x5b Counter(Ursarctic Big Dipper)
-!counter 0x105c Burnup Counter
+!counter 0x105c Burning Counter
 !counter 0x5d Counter(Gizmek Myth)
 !counter 0x5e Emperor's Key Counter
-!counter 0x5f Piece Counter
+!counter 0x5f Peace Counter
 !counter 0x60 Counter(Ursarctic Radiation)
 !counter 0x61 Counter(Prisoner of Destiny)
 !counter 0x62 Counter(Life Shaver)
 !counter 0x1063 Hallucination Counter
-!counter 0x64 GG Counter
+!counter 0x64 G Golem Counter
 !counter 0x1065 Bunny Ears Counter
 !counter 0x66 Counter(Gunkan Suship Chef's Choice)
 !counter 0x67 Counter(Combat Wheel)
@@ -662,8 +662,7 @@
 !counter 0x6a Resonance Counter
 !counter 0x106b Deranged Counter
 !counter 0x6c Access Counter
-!counter 0x6d Schoolwork Counter
-!counter 0x6e Season Counter
+!counter 0x6d Success Counter
 #setnames, using tab for comment
 !setname 0x1 Ally of Justice
 !setname 0x2 Genex
@@ -681,7 +680,7 @@
 !setname 0x5008 Vision HERO
 !setname 0xa008 Masked HERO
 !setname 0x9 Neos
-!setname 0xa lswarm
+!setname 0xa Lswarm
 !setname 0x100a Steelswarm
 !setname 0xb Infernity
 !setname 0xc Alien
@@ -699,7 +698,7 @@
 !setname 0x5013 Meklord Astro
 !setname 0x6013 Meklord Army
 !setname 0x15 B.E.S.
-!setname 0x16 roid
+!setname 0x16 Roid
 !setname 0x1016 Vehicroid
 !setname 0x2016 Speedroid
 !setname 0x17 Synchro
@@ -729,7 +728,7 @@
 !setname 0x2b Ninja
 !setname 0x102b Armor Ninja
 !setname 0x2c Flamvell
-!setname 0x2e Gravekeeper's
+!setname 0x2e Gravekeeper
 !setname 0x2f Ice Barrier
 !setname 0x30 Vylon
 !setname 0x31 Fortune Lady
@@ -741,7 +740,7 @@
 !setname 0x2034 Ultimate Crystal
 !setname 0x5034 Advanced Crystal Beast
 !setname 0x35 Fabled
-!setname 0x1035 Fabled
+!setname 0x1035 The Fabled
 !setname 0x36 Machina
 !setname 0x37 Mist Valley
 !setname 0x38 Lightsworn
@@ -799,7 +798,7 @@
 !setname 0x59 Gogogo
 !setname 0x5a Penguin
 !setname 0x5b Inmato
-!setname 0x5c sphinx
+!setname 0x5c Sphinx
 !setname 0x60 Bamboo Sword
 !setname 0x61 Ninjitsu Art
 !setname 0x62 Toon
@@ -850,7 +849,7 @@
 !setname 0x7e ZEXAL
 !setname 0x107e ZW -
 !setname 0x207e ZS -
-!setname 0x7f Utopic
+!setname 0x7f Utopi
 !setname 0x107f Utopia
 !setname 0x207f Utopic Future
 !setname 0x80 Duston
@@ -904,7 +903,7 @@
 !setname 0xa4 Kuriboh
 !setname 0x10a4 Winged Kuriboh
 !setname 0xa5 Change
-!setname 0xa6 sprout
+!setname 0xa6 Sprout
 !setname 0xa7 Artorigus
 !setname 0xa8 Laundsallyn
 !setname 0xa9 Fluffal
@@ -976,8 +975,8 @@
 !setname 0xde Exodia
 !setname 0xdf Lunalight
 !setname 0xe0 Amorphage
-!setname 0xe1 Metalfoes
-!setname 0xe2 Triamid
+!setname 0xe1 Metalphosis
+!setname 0xe2 Tramid
 !setname 0xe3 Cubic
 !setname 0xe4 Celtic Guard
 !setname 0xe5 Cipher
@@ -988,7 +987,7 @@
 !setname 0xe9 Magna Warrior
 !setname 0xea Crystron
 !setname 0xeb Chemicritter
-!setname 0xec Abyss-
+!setname 0xec Abyss
 !setname 0x10ec Abyss Actor
 !setname 0x20ec Abyss Script
 !setname 0xed Subterror
@@ -1011,7 +1010,7 @@
 #setcode 0xf8 Supreme King
 !setname 0x10f8 Supreme King Gate
 !setname 0x20f8 Supreme King Dragon
-!setname 0xf9 True Draco
+!setname 0xf9 True King
 !setname 0xf9 True Draco
 !setname 0xfa Phantasm Spiral
 !setname 0xfb Trickstar
@@ -1021,7 +1020,7 @@
 !setname 0xff Clear Wing
 !setname 0x100 Bonding
 !setname 0x101 code Talker
-!setname 0x102 Rokket
+!setname 0x102 rokket
 !setname 0x103 Altergeist
 !setname 0x104 Krawler
 !setname 0x105 Metaphys
@@ -1080,7 +1079,7 @@
 !setname 0x136 A.I.
 !setname 0x137 Ancient Warriors
 !setname 0x138 Megalith
-!setname 0x139 Palladium
+!setname 0x139 Palladium Oracle
 !setname 0x13a Onomat
 !setname 0x13b Rebellion
 !setname 0x13c Codebreaker
@@ -1123,7 +1122,7 @@
 !setname 0x155 Springans
 !setname 0x156 S-Force
 !setname 0x157 Myutant
-#setname 0x158 Sun
+#setname 0x158 サン
 !setname 0x1158 Sunvine
 !setname 0x2158 Sunavalon
 !setname 0x159 Starry Knight
@@ -1250,6 +1249,3 @@
 !setname 0x1c9 Dragon Tail
 !setname 0x1ca Yummy
 !setname 0x1cb K9
-!setname 0x1cc Teleport
-!setname 0x1cd Artmage
-!setname 0x1ce Imprisoned Deity


### PR DESCRIPTION
Reverting back en-US cards.cdb to 26 Apr version, so we can unblock the team from releasing DUAD updates and generating EN card images.

# Reason for revert
The format of card text in cdb file has been inversely affected by later commits(#120  #127) . Which includes inconsistent line breaking, line merging, random spaces, and some other formatting issues.

I have talked to ElderLich, fallenstardust and wind2009 and we agreed to reverse it to 26 Apr version. 

# What next

ElderLich will further resolve edge cases in the generated cdb before merging them to master. 

We will continue our work based on this cdb.

# Potential loss of contribution

This contribution from wind2009 will be lost: https://github.com/mycard/ygopro-database/commit/f74d36b09bbea94cc13ce7cf9744ac3e7e6b78cc

This is only a small change, wind2009 has acknowledged it and will update it again. 